### PR TITLE
Clarify build badge instructions in README.md

### DIFF
--- a/labs/lab02/README.md
+++ b/labs/lab02/README.md
@@ -235,13 +235,13 @@ The `develop` branch only exists on the local system.  To add it to GitHub we ha
 
 GitHub will have automatically added this branch to its build.  As `develop` is a key branch of our project we will add this build status to the `README.md` file.  
 
-This time I will use Shields.io to create a build badge. Go to [https://shields.io/category/build](https://shields.io/category/build) and select GitHub Workflow Status (branch). Fill in the UserName, RepositoryName, Workflow name (taken from the main.yml file)  and branch name
+This time I will use Shields.io to create a build badge. Go to [https://shields.io/category/build](https://shields.io/category/build) and select GitHub Workflow Status (branch). Fill in the UserName, RepositoryName, Workflow file name (main.yml) and branch name
 
 Update the `README.md` as below (keep the other badges):
 
 ```markdown
 # DevOps
-![GitHub Workflow Status (branch)](https://img.shields.io/github/workflow/status/<username>/<repository>/<action name taken from main.yml>/<branch>?style=flat-square)
+![GitHub Workflow Status (branch)](https://img.shields.io/github/actions/workflow/status/<username>/<repository>/<workflow file name>?branch=<branch>&style=flat-square)
 ```
 
 And add this to GitHub:


### PR DESCRIPTION
Updated instructions for adding a build badge to README.md, specifying 'workflow file name' instead of 'action name taken from main.yml'.